### PR TITLE
chore: :wrench: split configs for app, test, and node

### DIFF
--- a/apps/web-e2e/tsconfig.app.json
+++ b/apps/web-e2e/tsconfig.app.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@repo/typescript-config/tsconfig.playwright.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/apps/web-e2e/tsconfig.json
+++ b/apps/web-e2e/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "@repo/typescript-config/tsconfig.playwright.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
-    "types": ["node"]
-  },
-  "include": ["src", "playwright.config.ts"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
 }

--- a/apps/web-e2e/tsconfig.node.json
+++ b/apps/web-e2e/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/tsconfig.node.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts"]
+}

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -2,7 +2,8 @@
   "extends": "@repo/typescript-config/tsconfig.react-app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "src/**/setupTests.ts"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/tsconfig.react-app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/setupTests.ts"]
+}


### PR DESCRIPTION
This pull request refactors TypeScript configuration files for both the `web` and `web-e2e` apps to improve project organization and separation of concerns. The main changes involve splitting configurations for app, node, and test environments, clarifying type definitions, and excluding test files from production builds.

**TypeScript configuration restructuring:**

* Split the `apps/web-e2e/tsconfig.json` into separate references for app and node configurations, and created new `tsconfig.app.json` and `tsconfig.node.json` files for clearer environment separation. [[1]](diffhunk://#diff-78c74c37a72f287b8404cbb487a31124f9eeee098b2233e9762444e1afc4f477L2-R6) [[2]](diffhunk://#diff-7750ea79234de3cb97b23c72490ccb59b579bc276390a059cafc940a8f9dd7efR1-R7) [[3]](diffhunk://#diff-bab03afffca942169d3fcc099885584bb10f7d7ed763a2cfa1dcf946c66dc336R1-R8)
* Updated `apps/web/tsconfig.app.json` to remove test-related type definitions and explicitly exclude test files from the app build.
* Added a new `apps/web/tsconfig.test.json` to handle test-specific type definitions and file inclusion, ensuring tests are built separately from the main app.
* Modified `apps/web/tsconfig.json` to reference the new `tsconfig.test.json`, improving modularity and build clarity.