### PR TITLE
docs: :books: add template syncing guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ When the base template is updated (dependency changes, linting updates, or confi
 4. Run `pnpm install` to apply the updated files, then `pnpm build` and `pnpm test` to confirm the project still builds and passes.
 5. Merge into `main` with `git merge chore/sync-template-vX.Y.Z --no-ff` and push.
 
+> 💡 **Tip:** Record the synced version in `CHANGELOG.md` (e.g. `### Synced from react-vite-turborepo-template@vX.Y.Z`) so there's a dated history of which template version the project was aligned with at each sync.
+
 ## Testing
 
 Please write tests for any new features or modifications to the project. Follow these steps to ensure your tests are effective and consistent:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing! We welcome improvements and suggest
 - [Development Setup](#development-setup)
 - [Turborepo Tasks](#turborepo-tasks)
 - [Upgrading Dependencies](#upgrading-dependencies)
+- [Template Syncing](#template-syncing)
 - [Testing](#testing)
 - [Building](#building)
 - [Docker](#docker)
@@ -47,9 +48,9 @@ Turborepo tasks are defined in `turbo.json` at the root of the repository. Each 
 To add or extend shared tasks:
 
 - Define the task configuration in `turbo.json`.
-- Add or update the corresponding script in each relevant workspace’s `package.json`.
+- Add or update the corresponding script in each relevant workspace's `package.json`.
 
-> 💡 **Tip:** Turborepo’s dependency graph ensures that changes in one workspace only trigger necessary rebuilds and tests in dependent workspaces, streamlining both local development and CI pipelines.
+> 💡 **Tip:** Turborepo's dependency graph ensures that changes in one workspace only trigger necessary rebuilds and tests in dependent workspaces, streamlining both local development and CI pipelines.
 
 ## Upgrading Dependencies
 
@@ -65,6 +66,19 @@ Keeping dependencies up-to-date is crucial for maintaining the security and perf
 3. Rebuild all packages with `pnpm build` and run tests with `pnpm test` to ensure compatibility.
 4. Update the lockfile with `pnpm install` if needed.
 5. Commit your changes with a clear message and open a pull request for review.
+
+## Template Syncing
+
+When the base template is updated (dependency changes, linting updates, or config improvements), sync those changes into projects generated from it. Follow these steps:
+
+1. Create a sync branch: `git checkout -b chore/sync-template-vX.Y.Z`, replacing `vX.Y.Z` with the template tag you're syncing from.
+2. Apply the updated template files to the project, using whichever method best fits the scope of the change:
+   - `git cherry-pick` for porting specific commits from the template.
+   - `git apply`/`git diff` for applying a patch.
+   - A manual file copy for small, isolated changes.
+3. Commit all template changes together as a single atomic commit, following the [Commit Guidelines](#commit-guidelines) below.
+4. Run `pnpm install` to apply the updated files, then `pnpm build` and `pnpm test` to confirm the project still builds and passes.
+5. Merge into `main` with `git merge chore/sync-template-vX.Y.Z --no-ff` and push.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,13 +72,11 @@ Keeping dependencies up-to-date is crucial for maintaining the security and perf
 When the base template is updated (dependency changes, linting updates, or config improvements), sync those changes into projects generated from it. Follow these steps:
 
 1. Create a sync branch: `git checkout -b chore/sync-template-vX.Y.Z`, replacing `vX.Y.Z` with the template tag you're syncing from.
-2. Apply the updated template files to the project, using whichever method best fits the scope of the change:
-   - `git cherry-pick` for porting specific commits from the template.
-   - `git apply`/`git diff` for applying a patch.
-   - A manual file copy for small, isolated changes.
-3. Commit all template changes together as a single atomic commit, following the [Commit Guidelines](#commit-guidelines) below.
-4. Run `pnpm install` to apply the updated files, then `pnpm build` and `pnpm test` to confirm the project still builds and passes.
-5. Merge into `main` with `git merge chore/sync-template-vX.Y.Z --no-ff` and push.
+2. Copy the updated files from [react-vite-turborepo-template](https://github.com/andrewdyer/react-vite-turborepo-template) into your project, then resolve any project-specific differences manually.
+3. Review what changed with `git diff` to verify only intended template updates were introduced.
+4. Commit all template changes together as a single atomic commit, following the [Commit Guidelines](#commit-guidelines) below.
+5. Run `pnpm install` to apply the updated files, then `pnpm build` and `pnpm test` to confirm the project still builds and passes.
+6. Merge into `main` with `git merge chore/sync-template-vX.Y.Z --no-ff` and push.
 
 > 💡 **Tip:** Record the synced version in `CHANGELOG.md` (e.g. `### Synced from react-vite-turborepo-template@vX.Y.Z`) so there's a dated history of which template version the project was aligned with at each sync.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ When the base template is updated (dependency changes, linting updates, or confi
 3. Review what changed with `git diff` to verify only intended template updates were introduced.
 4. Commit all template changes together as a single atomic commit, following the [Commit Guidelines](#commit-guidelines) below.
 5. Run `pnpm install` to apply the updated files, then `pnpm build` and `pnpm test` to confirm the project still builds and passes.
-6. Merge into `main` with `git merge chore/sync-template-vX.Y.Z --no-ff` and push.
+6. Submit the sync branch using the standard pull request workflow in [Commit Guidelines](#commit-guidelines).
 
 > 💡 **Tip:** Record the synced version in `CHANGELOG.md` (e.g. `### Synced from react-vite-turborepo-template@vX.Y.Z`) so there's a dated history of which template version the project was aligned with at each sync.
 


### PR DESCRIPTION
This pull request updates project documentation to improve clarity and introduce new guidelines for template syncing. The main changes include adding a `CHANGELOG.md` file, updating the contributing guide to document template syncing procedures, and making minor style corrections.

**Documentation improvements:**

* Added a new `CHANGELOG.md` file to track notable changes and document adherence to Keep a Changelog and Semantic Versioning standards.
* Updated `CONTRIBUTING.md` to add a "Template Syncing" section, detailing the process for syncing changes from the base template and how to record these updates in the changelog. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R12) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R70-R84)

**Minor style and consistency fixes:**

* Fixed typographical inconsistencies in `CONTRIBUTING.md` (e.g., apostrophe usage in "workspace's" and "Turborepo's").