### PR TITLE
fix: release workflow token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,36 +15,37 @@ The release workflow requires GitHub Actions to have write access to the reposit
 3. Tick **Allow GitHub Actions to create and approve pull requests**
 4. Click **Save**
 
-> **Note:** For repositories within a GitHub Organisation, the same two settings must also be enabled at the organisation level under **Organisation Settings → Actions → General**. The organisation-level setting takes precedence over the repository-level one.
+> **Note:** For repositories within a GitHub Organisation, the same settings must also be enabled at the organisation level under **Organisation Settings → Actions → General**. Organisation-level settings take precedence over repository-level settings.
 
 ### Personal Access Token
 
-The release workflow uses a Personal Access Token (PAT) rather than the default `GITHUB_TOKEN`. `GITHUB_TOKEN` is blocked from opening pull requests in certain GitHub configurations — a PAT authenticates as the repository owner and sidesteps this restriction.
+The release workflow uses a Personal Access Token (PAT) to authenticate as the account that created it. This is required to create pull requests in certain GitHub configurations.
 
 **Generating the token:**
 
 1. Navigate to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
 2. Click **Generate new token (classic)**
-3. Set the following:
-   - **Note:** `release-please/<repository-name>` — a consistent naming pattern keeps tokens identifiable across repositories
-   - **Expiration:** 1 year — limits exposure if the token is ever compromised without requiring frequent rotation. Set a calendar reminder to renew it before expiry
-   - **Scopes:** `repo` and `workflow`
-4. Click **Generate token** and copy the value immediately — it will not be shown again
+3. Configure the token as follows:
+   - **Note:** `release-please/<repository-name>` — a consistent naming convention helps keep tokens identifiable across repositories
+   - **Expiration:** 1 year — limits exposure if a token is compromised whilst avoiding frequent rotation. Set a calendar reminder to renew the token before expiry
+   - **Scopes:** `repo` only — sufficient for Release Please to read repository contents and create pull requests. Add `workflow` only if release pull requests are expected to modify files under `.github/workflows/`
+4. Click **Generate token** and copy the value immediately, as it will not be displayed again
 
 **Adding the token to the repository:**
 
 1. Navigate to **Settings → Secrets and variables → Actions**
 2. Click **New repository secret**
-3. Set the name to `RELEASE_PLEASE_TOKEN` and paste the token value
-4. Click **Add secret**
+3. Set the name to `RELEASE_PLEASE_TOKEN`
+4. Paste the token value
+5. Click **Add secret**
 
-The release workflow is configured to use this secret — no changes to the workflow file are required.
+The release workflow is configured to use this secret and requires no further changes.
 
 ### Confirming the Release Workflow
 
-Push any commit to `main` and check the **Actions** tab. The Release workflow should complete without error and, if the commit contains a `feat` or `fix` type, open a version bump pull request within a few seconds.
+Push a commit to `main` and check the **Actions** tab. The Release workflow should complete successfully and, if the commit contains a version-bumping type (`feat`, `fix`, `perf`, or a breaking change), create a version bump pull request within a few seconds.
 
 If the workflow fails with a permissions error, the most likely causes are:
 
-- The repository secret name does not match `RELEASE_PLEASE_TOKEN` exactly
-- An organisation-level permissions setting is overriding the repository-level one
+- The repository secret name does not exactly match `RELEASE_PLEASE_TOKEN`
+- An organisation-level permissions setting is overriding the repository-level configuration

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,8 +39,6 @@ The release workflow uses a Personal Access Token (PAT) to authenticate as the a
 4. Paste the token value
 5. Click **Add secret**
 
-The release workflow is configured to use this secret and requires no further changes.
-
 ### Confirming the Release Workflow
 
 Push a commit to `main` and check the **Actions** tab. The Release workflow should complete successfully and, if the commit contains a version-bumping type (`feat`, `fix`, `perf`, or a breaking change), create a version bump pull request within a few seconds.
@@ -48,4 +46,4 @@ Push a commit to `main` and check the **Actions** tab. The Release workflow shou
 If the workflow fails with a permissions error, the most likely causes are:
 
 - The repository secret name does not exactly match `RELEASE_PLEASE_TOKEN`
-- An organization-level permissions setting is overriding the repository-level configuration
+- A token scope or token owner permission does not permit pull request creation

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,7 +15,7 @@ The release workflow requires GitHub Actions to have write access to the reposit
 3. Tick **Allow GitHub Actions to create and approve pull requests**
 4. Click **Save**
 
-> **Note:** For repositories within a GitHub Organisation, the same settings must also be enabled at the organisation level under **Organisation Settings → Actions → General**. Organisation-level settings take precedence over repository-level settings.
+> **Note:** For repositories within a GitHub Organization, the same settings must also be enabled at the organization level under **Organization Settings → Actions → General**. Organization-level settings take precedence over repository-level settings.
 
 ### Personal Access Token
 
@@ -48,4 +48,4 @@ Push a commit to `main` and check the **Actions** tab. The Release workflow shou
 If the workflow fails with a permissions error, the most likely causes are:
 
 - The repository secret name does not exactly match `RELEASE_PLEASE_TOKEN`
-- An organisation-level permissions setting is overriding the repository-level configuration
+- An organization-level permissions setting is overriding the repository-level configuration

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,50 @@
+# Setup
+
+One-time configuration required before the repository is fully operational. These steps should be completed before contributors are invited or pull requests are merged.
+
+---
+
+## GitHub Actions
+
+### Workflow Permissions
+
+The release workflow requires GitHub Actions to have write access to the repository and permission to open pull requests.
+
+1. Navigate to **Settings → Actions → General**
+2. Under **Workflow permissions**, select **Read and write permissions**
+3. Tick **Allow GitHub Actions to create and approve pull requests**
+4. Click **Save**
+
+> **Note:** For repositories within a GitHub Organisation, the same two settings must also be enabled at the organisation level under **Organisation Settings → Actions → General**. The organisation-level setting takes precedence over the repository-level one.
+
+### Personal Access Token
+
+The release workflow uses a Personal Access Token (PAT) rather than the default `GITHUB_TOKEN`. `GITHUB_TOKEN` is blocked from opening pull requests in certain GitHub configurations — a PAT authenticates as the repository owner and sidesteps this restriction.
+
+**Generating the token:**
+
+1. Navigate to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
+2. Click **Generate new token (classic)**
+3. Set the following:
+   - **Note:** `release-please/<repository-name>` — a consistent naming pattern keeps tokens identifiable across repositories
+   - **Expiration:** 1 year — limits exposure if the token is ever compromised without requiring frequent rotation. Set a calendar reminder to renew it before expiry
+   - **Scopes:** `repo` and `workflow`
+4. Click **Generate token** and copy the value immediately — it will not be shown again
+
+**Adding the token to the repository:**
+
+1. Navigate to **Settings → Secrets and variables → Actions**
+2. Click **New repository secret**
+3. Set the name to `RELEASE_PLEASE_TOKEN` and paste the token value
+4. Click **Add secret**
+
+The release workflow is configured to use this secret — no changes to the workflow file are required.
+
+### Confirming the Release Workflow
+
+Push any commit to `main` and check the **Actions** tab. The Release workflow should complete without error and, if the commit contains a `feat` or `fix` type, open a version bump pull request within a few seconds.
+
+If the workflow fails with a permissions error, the most likely causes are:
+
+- The repository secret name does not match `RELEASE_PLEASE_TOKEN` exactly
+- An organisation-level permissions setting is overriding the repository-level one


### PR DESCRIPTION
This pull request updates the release workflow to use a Personal Access Token (PAT) instead of the default `GITHUB_TOKEN` for creating release pull requests. It also adds detailed setup documentation to help maintainers configure the necessary GitHub Actions permissions and secrets for successful releases.

**Release workflow authentication:**
- [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R20): Changed the release workflow to use the `RELEASE_PLEASE_TOKEN` secret instead of `GITHUB_TOKEN` for authentication. This is necessary because `GITHUB_TOKEN` is blocked from opening pull requests in some GitHub configurations.

**Documentation improvements:**
- [`docs/setup.md`](diffhunk://#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23R1-R50): Added a comprehensive setup guide that explains how to configure workflow permissions and create the required `RELEASE_PLEASE_TOKEN` secret, including step-by-step instructions for both repository and organization settings.