### PR TITLE
chore(workflows): update authentication tokens 

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -33,8 +33,10 @@ runs:
       shell: bash
       env:
         INPUT_TOKEN: ${{ inputs.token }}
-        FALLBACK_TOKEN: ${{ github.token }}
       run: |
-        NODE_AUTH_TOKEN="${INPUT_TOKEN:-$FALLBACK_TOKEN}"
-        export NODE_AUTH_TOKEN
+        if [[ -n "$INPUT_TOKEN" ]]; then
+          export NODE_AUTH_TOKEN="$INPUT_TOKEN"
+        else
+          unset NODE_AUTH_TOKEN
+        fi
         pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           registry-url: https://npm.pkg.github.com
           scope: '@${{ github.repository_owner }}'
-          token: ${{ secrets.PACKAGES_READ_TOKEN }}
+          token: ${{ secrets.PACKAGES_TOKEN }}
 
       - name: Resolve component, path and version from tag
         id: tag
@@ -67,7 +67,7 @@ jobs:
         # Only run for workspace paths under packages/
         if: startsWith(steps.tag.outputs.path, 'packages/')
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
         run: |
           PATH_PREFIX="${{ steps.tag.outputs.path }}"
 
@@ -85,7 +85,7 @@ jobs:
           # version bumps, which would otherwise cause pnpm publish to fail.
           pnpm --filter "./$PATH_PREFIX" publish \
             --no-git-checks \
-            --access public
+            --access restricted
 
       - name: Login to GitHub Container Registry
         if: startsWith(steps.tag.outputs.path, 'apps/')
@@ -98,7 +98,7 @@ jobs:
       - name: Build and push Docker image
         if: startsWith(steps.tag.outputs.path, 'apps/')
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
         run: |
           APP_NAME=$(basename "${{ steps.tag.outputs.path }}")
           VERSION="${{ steps.tag.outputs.version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           registry-url: https://npm.pkg.github.com
           scope: '@${{ github.repository_owner }}'
-          token: ${{ secrets.PACKAGES_READ_TOKEN }}
+          token: ${{ secrets.PACKAGES_TOKEN }}
 
       - name: Build all packages
         run: pnpm turbo run build

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -33,7 +33,8 @@ To publish this package to GitHub Packages, make the following changes to `packa
 ```json
 {
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
   }
 }
 ```


### PR DESCRIPTION
## Description

This pull request updates authentication tokens and access configurations for publishing and installing packages, as well as clarifies documentation to match these changes. The main goals are to standardize the use of the `PACKAGES_TOKEN` secret and to ensure packages are published with restricted access.

## Proposed Changes

**Authentication and access configuration updates:**

* Replaced usage of `PACKAGES_READ_TOKEN` and `github.token` with `PACKAGES_TOKEN` for all npm-related authentication in workflow files, ensuring consistency and improved security. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L25-R25) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L70-R70) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L101-R101) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L32-R32)
* Changed the npm publish access from `public` to `restricted` in the publish workflow, so packages are not publicly accessible by default.

**Documentation updates:**

* Updated the `publishConfig` example in `packages/shared/README.md` to include `"access": "restricted"`, reflecting the new default publish access.

**Action script improvements:**

* Improved the logic in `.github/actions/pnpm-install/action.yml` to only set `NODE_AUTH_TOKEN` if an input token is provided, otherwise it unsets it, preventing accidental use of fallback tokens.


## Type of Change

- [ ] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `deps` — dependency update (patch version bump when releasable)
- [x] `chore` / `docs` / `refactor` / `test` / `ci` / `build` — no version bump
- [ ] `feat!` or `BREAKING CHANGE:` — breaking change (major version bump)

## Related Issue

N/A

## Checklist

- [ ] PR title follows Conventional Commits format: `<type>(<scope>): <description>` where scope is a workspace name from `apps/` or `packages/` (omit for repo-wide changes)
- [ ] Description is a single paragraph suitable for squash-merge commit body
- [ ] Code has been formatted with `pnpm format`
- [ ] Code has been linted with `pnpm lint`
- [ ] Tests have been added or updated where appropriate
- [ ] All tests pass with `pnpm test`
- [ ] Lockfile has been updated with `pnpm install` (deps changes only)
- [ ] Breaking changes in updated dependencies have been assessed (deps changes only)
- [ ] Fix has been verified in development (bug fixes only)
