### PR TITLE
ci: add storybook publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy app
+      - name: Deploy target
         env:
           APP: ${{ github.event.client_payload.app }}
           VERSION: ${{ github.event.client_payload.version }}
@@ -37,11 +37,11 @@ jobs:
           REPOSITORY=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/${REPOSITORY}-${APP}"
 
-          echo "Deploying $IMAGE:$VERSION..."
+          echo "🚀 Deploying $IMAGE:$VERSION..."
 
           # TODO: add your deployment logic here.
           # At this point the following variables are available:
-          #   APP     — the application name (e.g. "web")
+          #   APP     — the app or package-storybook name (e.g. "web" or "shared-storybook")
           #   IMAGE   — the GHCR image name
           #   VERSION — the released version (e.g. "1.2.3")
           echo "❌ Deployment logic not yet implemented"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,8 +65,30 @@ jobs:
           echo "path=$MATCHES" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check release kind
+        id: kind
+        env:
+          PACKAGE_PATH: ${{ steps.release.outputs.path }}
+        run: |
+          IS_APP=false
+          IS_PACKAGE=false
+          HAS_STORYBOOK=false
+
+          if [[ "$PACKAGE_PATH" == apps/* ]]; then
+            IS_APP=true
+          fi
+
+          if [[ "$PACKAGE_PATH" == packages/* ]]; then
+            IS_PACKAGE=true
+            HAS_STORYBOOK=$(node -p "!!require('./$PACKAGE_PATH/package.json').scripts?.['build:storybook']")
+          fi
+
+          echo "is_app=$IS_APP" >> "$GITHUB_OUTPUT"
+          echo "is_package=$IS_PACKAGE" >> "$GITHUB_OUTPUT"
+          echo "has_storybook=$HAS_STORYBOOK" >> "$GITHUB_OUTPUT"
+
       - name: Publish package to GitHub Packages
-        if: startsWith(steps.release.outputs.path, 'packages/')
+        if: steps.kind.outputs.is_package == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
           PACKAGE_PATH: ${{ steps.release.outputs.path }}
@@ -74,35 +96,76 @@ jobs:
           PRIVATE=$(node -p "require('./$PACKAGE_PATH/package.json').private ?? false")
 
           if [[ "$PRIVATE" == "true" ]]; then
-            echo "Skipping $PACKAGE_PATH (private package)"
+            echo "⏭️ Skipping $PACKAGE_PATH (private package)"
             exit 0
           fi
 
-          echo "Publishing $PACKAGE_PATH to GitHub Packages..."
+          echo "📦 Publishing $PACKAGE_PATH to GitHub Packages..."
           pnpm --filter "./$PACKAGE_PATH" publish \
             --no-git-checks \
             --access restricted
 
       - name: Login to GitHub Container Registry
-        if: startsWith(steps.release.outputs.path, 'apps/')
+        if: steps.kind.outputs.has_storybook == 'true' || steps.kind.outputs.is_app == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push Docker image
-        if: startsWith(steps.release.outputs.path, 'apps/')
+      - name: Build and push Storybook image
+        if: steps.kind.outputs.has_storybook == 'true'
         env:
-          APP_PATH: ${{ steps.release.outputs.path }}
+          PACKAGE_PATH: ${{ steps.release.outputs.path }}
           VERSION: ${{ steps.release.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
         run: |
-          APP=$(basename "$APP_PATH")
+          PACKAGE_DIR=$(basename "$PACKAGE_PATH")
+          PACKAGE_NAME=$(node -p "require('./$PACKAGE_PATH/package.json').name")
+          REPOSITORY=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPOSITORY}-${PACKAGE_DIR}-storybook"
+
+          echo "🐳 Building and pushing $IMAGE:$VERSION..."
+
+          TOKEN_FILE=$(mktemp)
+          trap 'rm -f "$TOKEN_FILE"' EXIT
+          printf '%s' "$NODE_AUTH_TOKEN" > "$TOKEN_FILE"
+
+          docker build \
+            --secret id=npm_token,src="$TOKEN_FILE" \
+            --build-arg PACKAGE_NAME="$PACKAGE_NAME" \
+            --build-arg PACKAGE_PATH="$PACKAGE_PATH" \
+            -f Dockerfile.storybook \
+            -t "$IMAGE:$VERSION" \
+            -t "$IMAGE:latest" \
+            .
+
+          docker push "$IMAGE:$VERSION"
+          docker push "$IMAGE:latest"
+
+          STORYBOOK_TARGET="${PACKAGE_DIR}-storybook"
+
+          echo "🚀 Dispatching deploy event for $STORYBOOK_TARGET@$VERSION..."
+
+          curl --fail --show-error \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -d "{\"event_type\":\"deploy\",\"client_payload\":{\"app\":\"$STORYBOOK_TARGET\",\"version\":\"$VERSION\"}}"
+
+      - name: Build and push app image
+        if: steps.kind.outputs.is_app == 'true'
+        env:
+          PACKAGE_PATH: ${{ steps.release.outputs.path }}
+          VERSION: ${{ steps.release.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
+        run: |
+          APP=$(basename "$PACKAGE_PATH")
           REPOSITORY=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/${REPOSITORY}-${APP}"
 
-          echo "Building and pushing $IMAGE:$VERSION..."
+          echo "🐳 Building and pushing $IMAGE:$VERSION..."
 
           TOKEN_FILE=$(mktemp)
           trap 'rm -f "$TOKEN_FILE"' EXIT
@@ -119,7 +182,7 @@ jobs:
           docker push "$IMAGE:$VERSION"
           docker push "$IMAGE:latest"
 
-          echo "Dispatching deploy event for $APP@$VERSION..."
+          echo "🚀 Dispatching deploy event for $APP@$VERSION..."
 
           curl --fail --show-error \
             -X POST \

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       app:
-        description: App to roll back
+        description: App or package Storybook to roll back
         required: true
         type: choice
         options:
           - web
+          - shared-storybook
       version:
         description: Version to roll back to (e.g. "1.2.3")
         required: true
@@ -38,7 +39,7 @@ jobs:
             exit 1
           fi
 
-      - name: Rollback app
+      - name: Rollback target
         env:
           APP: ${{ inputs.app }}
           VERSION: ${{ inputs.version }}
@@ -46,11 +47,11 @@ jobs:
           REPOSITORY=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/${REPOSITORY}-${APP}"
 
-          echo "Rolling back to $IMAGE:$VERSION..."
+          echo "⏪ Rolling back to $IMAGE:$VERSION..."
 
           # TODO: add your rollback logic here.
           # At this point the following variables are available:
-          #   APP     — the application name (currently "web")
+          #   APP     — the app or package-storybook name (e.g. "web" or "shared-storybook")
           #   IMAGE   — the GHCR image name
           #   VERSION — the version to roll back to (e.g. "1.2.3")
           echo "❌ Rollback logic not yet implemented"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,10 @@ WORKDIR /app
 # Enable corepack so pnpm can be used
 RUN corepack enable
 
-# Install Turbo globally for monorepo tasks
-RUN npm install -g turbo
+# Install Turbo globally for monorepo tasks, pinned to match the version in
+# package.json so this build stays reproducible instead of picking up
+# whatever is newest on npm at build time
+RUN npm install -g turbo@2.10.4
 
 
 # =============================
@@ -67,7 +69,7 @@ RUN pnpm turbo run build --filter=${APP_NAME}...
 # Stage 4 — Runtime
 # Serves the built app using Nginx
 # =============================
-FROM nginx:alpine AS runtime
+FROM nginx:1.31.3-alpine AS runtime
 
 # Name of the app to serve
 ARG APP_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY --from=prune /app/out/full/ ./
 ARG APP_NAME
 
 # Build the selected app with Turbo
-RUN pnpm turbo run build --filter=${APP_NAME}...
+RUN pnpm exec turbo run build --filter=${APP_NAME}...
 
 
 # =============================

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -63,7 +63,7 @@ COPY --from=prune /app/out/full/ ./
 ARG PACKAGE_NAME
 
 # Build the selected package's Storybook with Turbo
-RUN pnpm turbo run build:storybook --filter=${PACKAGE_NAME}
+RUN pnpm exec turbo run build:storybook --filter=${PACKAGE_NAME}
 
 
 # =============================

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -1,0 +1,88 @@
+# =============================
+# Stage 1 — Base image
+# Provides Node.js, pnpm, and Turbo for all later stages
+# =============================
+FROM node:24.19.0-alpine AS base
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Enable corepack so pnpm can be used
+RUN corepack enable
+
+# Install Turbo globally for monorepo tasks
+RUN npm install -g turbo
+
+
+# =============================
+# Stage 2 — Prune
+# Reduces the monorepo down to only the selected package and its dependencies
+# =============================
+FROM base AS prune
+
+# npm name of the package to prune, e.g. "@repo/shared" - turbo prune
+# requires the package.json "name" field here, not a workspace path
+ARG PACKAGE_NAME
+
+# Copy the entire repo (required for Turbo prune)
+COPY . .
+
+# Prune the repo for the selected package
+RUN turbo prune ${PACKAGE_NAME} --docker
+
+
+# =============================
+# Stage 3 — Build
+# Installs deps and builds the selected package's Storybook for production
+# =============================
+FROM base AS build
+
+# Copy pruned package.json files
+COPY --from=prune /app/out/json/ ./
+
+# Copy pruned pnpm lockfile
+COPY --from=prune /app/out/pnpm-lock.yaml ./
+
+# Install dependencies before copying the full source so this layer remains
+# cached when only application code changes. If the npm_token build secret
+# is provided, the auth token is appended to .npmrc before install and
+# removed immediately after so no credentials are stored in the image.
+RUN --mount=type=secret,id=npm_token,required=false \
+    if [ -f /run/secrets/npm_token ] && [ -s /run/secrets/npm_token ]; then \
+    printf "\n//npm.pkg.github.com/:_authToken=%s\n" "$(cat /run/secrets/npm_token)" >> .npmrc; \
+    fi && \
+    pnpm install --frozen-lockfile && \
+    rm -f .npmrc
+
+# Copy pruned full source code
+COPY --from=prune /app/out/full/ ./
+
+# npm name of the package to build, e.g. "@repo/shared"
+ARG PACKAGE_NAME
+
+# Build the selected package's Storybook with Turbo
+RUN pnpm turbo run build:storybook --filter=${PACKAGE_NAME}
+
+
+# =============================
+# Stage 4 — Runtime
+# Serves the built Storybook using Nginx
+# =============================
+FROM nginx:alpine AS runtime
+
+# Workspace path of the package being served, e.g. "packages/shared" - used
+# to locate the build output and nginx config, since it can differ from
+# PACKAGE_NAME (a scoped npm name isn't a valid filesystem path)
+ARG PACKAGE_PATH
+
+# Copy the built Storybook from the build stage
+COPY --from=build /app/${PACKAGE_PATH}/storybook-static /usr/share/nginx/html
+
+# Copy the package's own Nginx server configuration
+COPY ${PACKAGE_PATH}/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80 for HTTP traffic
+EXPOSE 80
+
+# Start Nginx in the foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -10,8 +10,10 @@ WORKDIR /app
 # Enable corepack so pnpm can be used
 RUN corepack enable
 
-# Install Turbo globally for monorepo tasks
-RUN npm install -g turbo
+# Install Turbo globally for monorepo tasks, pinned to match the version in
+# package.json so this build stays reproducible instead of picking up
+# whatever is newest on npm at build time
+RUN npm install -g turbo@2.10.4
 
 
 # =============================
@@ -68,7 +70,7 @@ RUN pnpm turbo run build:storybook --filter=${PACKAGE_NAME}
 # Stage 4 — Runtime
 # Serves the built Storybook using Nginx
 # =============================
-FROM nginx:alpine AS runtime
+FROM nginx:1.31.3-alpine AS runtime
 
 # Workspace path of the package being served, e.g. "packages/shared" - used
 # to locate the build output and nginx config, since it can differ from

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -23,8 +23,7 @@ server {
   # route, so we don't fall back to index.html like the block below does
   location /assets/ {
     try_files $uri =404;
-    expires 1y;
-    add_header Cache-Control "public, immutable";
+    add_header Cache-Control "public, max-age=31536000, immutable";
   }
 
   # index.html must always be revalidated with the server before being served

--- a/packages/shared/nginx.conf
+++ b/packages/shared/nginx.conf
@@ -1,0 +1,44 @@
+server {
+  # Nginx listens on port 80 by default
+  listen 80;
+
+  # Use localhost for development, or your domain for production
+  server_name localhost;
+
+  # The root directory containing the built Storybook
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Hide the nginx version in response headers
+  server_tokens off;
+
+  # Compress text-based assets before sending to the browser
+  gzip on;
+  gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+  gzip_min_length 1024;
+
+  # Storybook outputs hashed, content-addressed filenames into /assets/, so
+  # these are safe to cache forever - the filename itself changes if the
+  # content does. A missing file here is a genuine 404
+  location /assets/ {
+    try_files $uri =404;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+
+  # index.html and iframe.html are Storybook's entry points and aren't
+  # content-hashed, so they must always be revalidated with the server to
+  # pick up a new build after every deploy
+  location ~ ^/(index|iframe)\.html$ {
+    add_header Cache-Control "no-cache";
+  }
+
+  # Storybook navigates between stories with a `?path=` query string on a
+  # single page rather than distinct server-side routes, so unlike a SPA,
+  # there's no fallback to index.html for arbitrary paths here - falling
+  # through to $uri/ only serves the index directive above for directory
+  # requests like `/`, and a genuinely missing file is still a real 404
+  location / {
+    try_files $uri $uri/ =404;
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces automated Storybook Docker image builds and deployments for packages with Storybook support, alongside several workflow improvements and supporting configuration. The main changes include a new multi-stage `Dockerfile.storybook`, workflow logic for building and deploying Storybook containers, and Nginx configuration for serving Storybook. It also generalizes deployment and rollback workflows to support both apps and Storybook targets.

## Proposed Changes

**Storybook Docker image support:**

* Added `Dockerfile.storybook`, a multi-stage Dockerfile that prunes the monorepo, builds the selected package's Storybook, and serves it via Nginx.
* Added `packages/shared/nginx.conf` to provide a secure, production-ready Nginx configuration for serving built Storybook assets.

**Workflow enhancements for Storybook and apps:**

* Updated `.github/workflows/publish.yml` to detect Storybook support in packages, build and push Storybook Docker images, and dispatch deploy events for both apps and Storybook containers. Enhanced output messages for clarity. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R68-R168) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L122-R185)
* Updated `.github/workflows/deploy.yml` and `.github/workflows/rollback.yml` to generalize terminology and logic to support deploying and rolling back both apps and Storybook containers, including improved descriptions and output messages. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L32-R44) [[2]](diffhunk://#diff-5c058b6cf60bbe00e47c50fc6518308faed2bade13792b22f4c57401d9a0b2d2L7-R12) [[3]](diffhunk://#diff-5c058b6cf60bbe00e47c50fc6518308faed2bade13792b22f4c57401d9a0b2d2L41-R54)

## Type of Change

- [x] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `deps` — dependency update (patch version bump when releasable)
- [ ] `chore` / `docs` / `refactor` / `test` / `ci` / `build` — no version bump
- [ ] `feat!` or `BREAKING CHANGE:` — breaking change (major version bump)

## Related Issue

N/A

## Checklist

- [x] PR title follows Conventional Commits format: `<type>(<scope>): <description>` where scope is a workspace name from `apps/` or `packages/` (omit for repo-wide changes)
- [x] Description is a single paragraph suitable for squash-merge commit body
- [ ] Code has been formatted with `pnpm format`
- [ ] Code has been linted with `pnpm lint`
- [ ] Tests have been added or updated where appropriate
- [ ] All tests pass with `pnpm test`
- [ ] Lockfile has been updated with `pnpm install` (deps changes only)
- [ ] Breaking changes in updated dependencies have been assessed (deps changes only)
- [ ] Fix has been verified in development (bug fixes only)
